### PR TITLE
Fix typing error in findChannel function

### DIFF
--- a/Modules/Utils.js
+++ b/Modules/Utils.js
@@ -170,7 +170,7 @@ module.exports = {
             if (notify) {
                 module.exports.logError(
                     `[Utils] [findChannel] ${chalk.bold(
-                        "name"
+                        name
                     )} was not found in the ${chalk.bold(guild.name)} guild`
                 );
             }


### PR DESCRIPTION
Because of fact, that _name_ is in quotes, error(channel was not found) prints "name" instead of channel name.

So, there is a fix(I know, this is BIG PR)