### PR TITLE
Added Settings.DevMode functionality

### DIFF
--- a/src/Modules/Structures/Handlers/Addons.ts
+++ b/src/Modules/Structures/Handlers/Addons.ts
@@ -76,7 +76,7 @@ export class Addon {
         for (let i = 0; i < configKeys.length; i++) {
             if (!fs.existsSync(`./data/Addon Configs/${this.name}`)) fs.mkdirSync(`./data/Addon Configs/${this.name}`);
             /** @ts-ignore */
-            const config = new Config(path.join(__dirname, `../../../../data/Addon Configs/${this.name}/${configKeys[i]}.yml`), configs[configKeys[i]]);
+            const config = new Config(path.join(__dirname, `../../../../data/Addon Configs/${this.name}/${configKeys[i]}.yml`), configs[configKeys[i]], manager.configs.config.Settings.DevMode);
 
             /** @ts-ignore */
             returnConfigValue[configKeys[i]] = config.getFile();

--- a/src/Modules/Structures/Handlers/Config.ts
+++ b/src/Modules/Structures/Handlers/Config.ts
@@ -47,14 +47,14 @@ export class Config {
     public configData: any;
     public configName: string | undefined;
 
-    constructor(storagePath: string, configData: any) {
+    constructor(storagePath: string, configData: any, force: boolean = false) {
         if (!storagePath) throw new Error("[BrayanBot/ConfigHandler] storagePath manager parameter.");
         if (!configData) throw new Error("[BrayanBot/ConfigHandler] configData manager parameter.");
 
         this.storagePath = storagePath;
         this.configData = configData;
         
-        if(!this.fileExists()) {
+        if(!this.fileExists() || force) {
             this.createFile();
         }
 


### PR DESCRIPTION
This PR adds old `Settings.DevMode` option functionality from BB's legacy version - `Settings.DevMode` set to true regenerates addon configs after reboot.